### PR TITLE
Fix initialization error if LibMSP is loaded twice

### DIFF
--- a/LibMSP.lua
+++ b/LibMSP.lua
@@ -332,7 +332,7 @@ setmetatable(msp.char, mspCharMeta)
 
 for charName, charTable in pairs(msp.char) do
 	setmetatable(charTable, charMeta)
-	if rawget(charTable.field) then
+	if rawget(charTable, "field") then
 		setmetatable(charTable.field, emptyMeta)
 	end
 end


### PR DESCRIPTION
If LibMSP is loaded once, msp.char is populated, and LibMSP is then loaded by another addon it attempts to fix up the msp.char table by assigning metatables on the present data.

It'll test for the field table on the character data via rawget, but incorrectly doesn't pass the "field" key as a separate argument to rawget thus triggering an error.