### PR TITLE
Remove assumption that unit fields won't change

### DIFF
--- a/LibMSP.lua
+++ b/LibMSP.lua
@@ -58,7 +58,6 @@ local TT_ALL = {
 	RA = true, CU = true, FR = true, FC = true,	RC = true, CO = true,
 	IC = true, PX = true,
 }
-local UNIT_FIELD = { GC = true, GF = true, GR = true, GS = true, GU = true, }
 local INTERNAL_FIELDS = {
 	VP = true, GC = true, GF = true, GR = true, GS = true, GU = true,
 }
@@ -451,9 +450,7 @@ function Process(name, command, isSafe)
 	elseif action == "" and isSafe then
 		msp.char[name].field[field] = contents
 		msp.char[name].ver[field] = crcNum
-		-- Assume unit fields won't change during a session, so only request
-		-- them once after getting a response.
-		msp.char[name].time[field] = not UNIT_FIELD[field] and now or TIME_MAX
+		msp.char[name].time[field] = now
 		if field == "TT" then
 			for ttField in pairs(msp.ttAll) do
 				-- Clear fields that haven't been updated in PROBE_FREQUENCY,


### PR DESCRIPTION
This is incorrect in a few edge cases - the first is something that LibMSP tries to account for where a neutral-faction Pandaren is created and then selects a faction later on in the levelling process. LibMSP updates the `msp.my` data automatically in this case, however any other players that queried for the "GF" field before that change occurred would never see the updated faction once selected.

The other edge case is where a character is deleted and recreated, in this case basically any and all of the unit fields could change with the GU (GUID) being a guarantee.

Odds are the only reason this was never noticed was because these fields probably aren't used by many people, however rather than keep a broken assumption around it's better to fix this before we forget about it and move on only to then get bitten
 ourselves one day in the far future.

Realistically since these fields are seldom used, the impact of allowing them to be re-requested as frequently as other fields shouldn't be a problem - and in the grand scheme of things the data these fields would otherwise transmit should be minimal at best, especially given the common case of them not actually changing.

To demonstrate I ran a quick test ingame without and then with this change applied, first starting off with a Human Warrior that was deleted and recreated as a Paladin:

Initial request:

![image](https://user-images.githubusercontent.com/287102/106680879-440c2800-65b7-11eb-9329-d3de73b5a9a1.png)

Post-recreation:

![image](https://user-images.githubusercontent.com/287102/106680887-49697280-65b7-11eb-90f0-022d1878d1ad.png)

As the `time` values for the unit fields was set astronomically high, any re-requests for them were never honored and LibMSP was stuck with some old data.

With the change applied, the initial request fetched the Paladin data:

![image](https://user-images.githubusercontent.com/287102/106680989-7fa6f200-65b7-11eb-89be-fb1a8cb236f7.png)

The time fields are no longer set to high values, and so when the Paladin transformed into a Monk a re-request went through successfully and LibMSP was no longer wrong:

![image](https://user-images.githubusercontent.com/287102/106681024-92212b80-65b7-11eb-894f-b7b713646d33.png)
