### PR TITLE
Improve CRC32 performance

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -56,6 +56,7 @@ stds.wowstd = {
 	read_globals = {
 		bit = {
 			fields = {
+				"arshift",
 				"bxor",
 				"band",
 				"rshift",

--- a/LibMSP.lua
+++ b/LibMSP.lua
@@ -245,19 +245,34 @@ local CRC32C = {
 }
 
 local function crc32c_hash(s)
-	local XOR, AND, RSHIFT, byte = bit.bxor, bit.band, bit.rshift, string.byte
+	local bxor, band, brshift, strbyte = bit.bxor, bit.band, bit.rshift, string.byte
+
 	local crc = 0xffffffff
-	for i = 1, #s do
-		local b = byte(s, i)
-		crc = XOR(RSHIFT(crc, 8), CRC32C[AND(XOR(crc, b), 0xFF) + 1])
+	local len = #s
+
+	for i = 1, len - 7, 8 do
+		local b1, b2, b3, b4, b5, b6, b7, b8 = strbyte(s, i, i + 7)
+
+		crc = bxor(brshift(crc, 8), CRC32C[band(bxor(crc, b1), 0xFF) + 1])
+		crc = bxor(brshift(crc, 8), CRC32C[band(bxor(crc, b2), 0xFF) + 1])
+		crc = bxor(brshift(crc, 8), CRC32C[band(bxor(crc, b3), 0xFF) + 1])
+		crc = bxor(brshift(crc, 8), CRC32C[band(bxor(crc, b4), 0xFF) + 1])
+		crc = bxor(brshift(crc, 8), CRC32C[band(bxor(crc, b5), 0xFF) + 1])
+		crc = bxor(brshift(crc, 8), CRC32C[band(bxor(crc, b6), 0xFF) + 1])
+		crc = bxor(brshift(crc, 8), CRC32C[band(bxor(crc, b7), 0xFF) + 1])
+		crc = bxor(brshift(crc, 8), CRC32C[band(bxor(crc, b8), 0xFF) + 1])
 	end
-	return XOR(crc, 0xffffffff)
+
+	for i = (len - (len % 8)) + 1, len do
+		local b = strbyte(s, i)
+		crc = bxor(brshift(crc, 8), CRC32C[band(bxor(crc, b), 0xFF) + 1])
+	end
+
+	return bxor(crc, 0xffffffff)
 end
 
 local function tohex(n)
-	local high = bit.rshift(n, 16)
-	local low = n % 0x10000
-	return ("%04X%04X"):format(high, low):match("^0*(%x-)$")
+	return string.format("%.X", bit.arshift(n, 0))
 end
 
 local function crc32c_tostring(s)

--- a/LibMSP.lua
+++ b/LibMSP.lua
@@ -290,6 +290,10 @@ local CRC32CCache = setmetatable({}, {
 	end,
 })
 
+function msp:CRC32(s)
+	return tonumber(CRC32CCache[s], 16);
+end
+
 -- Benchmarking function.
 function msp:DebugHashTest(text, silent)
 	local startTime = debugprofilestop()

--- a/LibMSP.lua
+++ b/LibMSP.lua
@@ -337,6 +337,13 @@ local mspCharMeta = {
 		if not rawget(self, name) then
 			rawset(self, name, setmetatable({}, charMeta))
 			RunCallback("dataload", name, self[name])
+
+			local fields = rawget(self, name).field;
+			local ver = rawget(self, name).ver;
+
+			for field, value in pairs(fields) do
+				ver[field] = ver[field] or tonumber(CRC32CCache[value], 16);
+			end
 		end
 		return rawget(self, name)
 	end,


### PR DESCRIPTION
This changeset improves the performance of the CRC32 hash function by approximately ~10% (increasing with larger payload sizes) by unrolling loop to reduce the number of `string.byte` calls to deal with bytes in blocks of 8.

Additionally the `tohex` function has been simplified to use `string.format` with `bit.arshift`, which works around the overflow issue it was trying to avoid by ensuring that inputs to `string.format` are signed when above 2^31-1.

Unfortunately I lost the specific test data I was using, but the before/after should show below quite well. The test strings used for the benchmark were strings of mixed length (0, 10, 25, 50, 200, and 1000 in-order). The tests were run 10 times without and with the changes:

![image](https://user-images.githubusercontent.com/287102/106687235-a9661600-65c3-11eb-8c32-eb4efd2b4c82.png)

With changes applied:

![image](https://user-images.githubusercontent.com/287102/106687306-cd295c00-65c3-11eb-945f-c6bac395147f.png)

While the zero-byte string case gets worse, I think it's _likely_ that there aren't going to be many zero byte strings being hashed. The gains from everything larger than that should outweigh the hits taken by _very_ small strings.
