### PR TITLE
Ensure AddFieldsToTooltip only adds fields once

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -61,5 +61,7 @@ stds.wowstd = {
 				"rshift",
 			},
 		},
+
+		"tContains",
 	},
 }

--- a/LibMSP.lua
+++ b/LibMSP.lua
@@ -359,7 +359,9 @@ local function AddTTField(field)
 	if type(field) ~= "string" or not field:find("^%u%u$") then
 		error("msp:AddFieldsToTooltip(): All fields must be strings matching Lua pattern \"%u%u\".", 3)
 	end
-	msp.ttList[#msp.ttList + 1] = field
+	if not tContains(msp.ttList, field) then
+		msp.ttList[#msp.ttList + 1] = field
+	end
 	if not msp.ttAll[field] then
 		msp.ttAll[field] = true
 	end


### PR DESCRIPTION
If AddFieldsToTooltip is called with any field names already registered in the `ttList` table, the AddTTField function would insert the field again into the list.

This would then manifest in a later Update call by and cause the duplicated fields to appear twice in the canned `ttContents`/`ttCache` responses needlessly.

Checking if the table contains the field prior to adding ensures we don't duplicate the field and keeps the size of TT field responses down.

Before, we can see that if `AddFieldsToTooltip` is called with some fields they'll be duplicated in the cache - see the "VA" field near the start and end:

![image](https://user-images.githubusercontent.com/287102/106810974-9572f080-6665-11eb-9266-3c978fd35036.png)

With the change applied, the same test won't cause a duplicate "VA" field to be present in the cached string:

![image](https://user-images.githubusercontent.com/287102/106811006-a15eb280-6665-11eb-90d7-e278e3e4d8a8.png)

