### PR TITLE
Autofill TR field from account status

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -41,6 +41,8 @@ stds.wow = {
 		"IsInGroup",
 		"IsInRaid",
 		"IsLoggedIn",
+		"IsTrialAccount",
+		"IsVeteranTrialAccount",
 		"LE_REALM_RELATION_COALESCED",
 		"MAX_PARTY_MEMBERS",
 		"MAX_RAID_MEMBERS",

--- a/LibMSP.lua
+++ b/LibMSP.lua
@@ -604,6 +604,15 @@ local function EventFrame_Handler(self, event, ...)
 		msp.my.GR = tostring(GR)
 		msp.my.GS = tostring(GS)
 		msp.my.GF = tostring(GF)
+
+		if IsTrialAccount() then
+			msp.my.TR = "1"
+		elseif IsVeteranTrialAccount() then
+			msp.my.TR = "2"
+		else
+			msp.my.TR = "0"
+		end
+
 		if GF == "Neutral" then
 			self:RegisterEvent("NEUTRAL_FACTION_SELECT_RESULT")
 		end


### PR DESCRIPTION
The TR field (trial account status) was added a while back for transmission via MSP in #19; as it stands this field has a fixed set of values and can easily be implemented by LibMSP itself similar to the existing unit fields like GU/GC/GR, which means all the addons that want to supply it don't need to copy the exact same snippet of code to fill these fields in.